### PR TITLE
Bugfix - Stamp button was always selecting the first stamp in the list

### DIFF
--- a/app/client/actions/index.es6
+++ b/app/client/actions/index.es6
@@ -18,11 +18,11 @@ export const selectStamp = (stampId) => {
   return (dispatch, getState) => {
     const selectedStamp = getState().stampsInfo.stamps.filter((stamp) => {
       return (stamp.id == stampId);
-    })[0]
-    return {
+    })[0];
+    return dispatch({
       type: SELECT_STAMP,
       selectedStamp
-    }
+    });
   }
 }
 


### PR DESCRIPTION
By default the stamp selected was always the first in the stamp <select>. This was happening because the operation was never being executed, which was caused because this action of returning an operation for SELECT_STAMP was inside a function, and it requires an explicit dispatch of the operation when is inside a function, instead of just returning the value