### PR TITLE
Design

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -61,11 +61,15 @@ body#login {
   background-color: #e0ebeb;
 }
 
-.container#login_box, .container#search{
-  margin-top: 20px;
-  padding-bottom: 10px;
-  background-color: white;
-  margin-bottom: 20px;
+.container {
+  &#login_box, &#search {
+    margin-top: 20px;
+    padding-bottom: 10px;
+    background-color: white;
+  }
+  &#login {
+    margin-bottom: 20px;
+  }
 }
 
 /* Disable text-wrapping on the advanced set-shaper table to save vertical space*/
@@ -77,8 +81,16 @@ body#login {
 .bg-info, .alert-info {
   background-color: #d9edf7;
 }
+
+/* Change alert font colour from white to grey */
 .alert {
   color: #444;
+}
+
+ul.pagination {
+  margin-right: 15px;
+  margin-top: 5px;
+  margin-bottom: 5px;
 }
 
 h1 {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -93,6 +93,19 @@ ul.pagination {
   margin-bottom: 5px;
 }
 
+/* Positioning for set creation buttons*/
+#create-set-btn {
+  margin-left: 20px;
+}
+.mat-btn {
+  margin-top: 8px;
+  margin-right: 5px;
+}
+.stamp-btn {
+  margin-top: 8px;
+  margin-right: 5px;
+}
+
 h1 {
   margin-top: 0;
   font-size: 40px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -98,6 +98,11 @@ h1 {
   font-size: 40px;
 }
 
+.popover {
+  margin-top: 20px;
+  max-width: 600px;
+}
+
 /* Emphasize the nav button of the current page */
 #current_page {
   background-color: #0073e6;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -82,8 +82,8 @@ body#login {
   background-color: #d9edf7;
 }
 
-/* Change alert font colour from white to grey */
-.alert {
+/* Change alert-info font colour from white to grey */
+.alert-info {
   color: #444;
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -103,6 +103,10 @@ h1 {
   max-width: 600px;
 }
 
+.navbar-text {
+  color: #b2dbfb !important;
+}
+
 /* Emphasize the nav button of the current page */
 #current_page {
   background-color: #0073e6;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -94,16 +94,14 @@ ul.pagination {
 }
 
 /* Positioning for set creation buttons*/
-#create-set-btn {
-  margin-left: 20px;
-}
-.mat-btn {
+.set-btn {
   margin-top: 8px;
   margin-right: 5px;
 }
-.stamp-btn {
-  margin-top: 8px;
-  margin-right: 5px;
+
+.remove-filter-row {
+  padding: 5px;
+  margin-top: 2px;
 }
 
 h1 {

--- a/app/client/components/filter_panel.es6
+++ b/app/client/components/filter_panel.es6
@@ -78,14 +78,14 @@ export class FilterRow extends React.Component {
             { options }
           </select>
         </div>
-        <div className="col-md-2">
+        <div className="col-md-3">
           <ContextualComparator filter={filter} fields={fields} onChange={onComparatorChange} />
         </div>
         <div className="col-md-4">
           <ContextualValue filter={filter} fields={fields} onChange={onValueChange}/>
         </div>
-        <div className="col-md-2">
-          <button onClick={onRemove} type="submit" className="btn btn-link remove-filter-row">
+        <div className="col-md-1">
+          <button onClick={onRemove} type="submit" className="btn btn-link remove-filter-row pull-right">
             <FontAwesome icon="times" size="lg" style={{color: 'red'}} />
           </button>
         </div>

--- a/app/client/components/filter_panel.es6
+++ b/app/client/components/filter_panel.es6
@@ -42,8 +42,6 @@ class FilterPanel extends React.Component {
           <span style={{ color: '#367FD2', width: '400px' }}>What&#39;s this?</span>
         </OverlayTrigger></Heading>
         <Body>
-
-
           <CSSTransitionGroup transitionName="example" transitionEnterTimeout={1000} transitionLeaveTimeout={300}>
             {filter_rows}
           </CSSTransitionGroup>
@@ -74,7 +72,7 @@ export class FilterRow extends React.Component {
       <div className="row" style={{'marginBottom': '10px'}}>
         <div className="col-md-4">
           <select value={filter.name} className="form-control change-field-name" onChange={onNameChange}>
-            <option value='' key='empty key'> </option>
+            <option value='' key='empty key' disabled>Property</option>
             { options }
           </select>
         </div>
@@ -99,7 +97,7 @@ export class ContextualComparator extends React.Component {
   render() {
     const {filter, fields, onChange} = this.props;
     const field = fields[filter.name];
-    const options = (field) ? field.comparators : [];
+    const options = (field) ? field.comparators : ['Comparator'];
     return <ListField value={filter.comparator} options={options} onChange={onChange} />
   }
 
@@ -134,7 +132,7 @@ export class ContextualValue extends React.Component {
 }
 
 const InputTextField = ({value, onChange}) => {
-  return <input type="text" className="form-control" onChange={onChange} value={value} />
+  return <input type="text" className="form-control" onChange={onChange} value={value} placeholder={'Value'} />
 };
 
 const ListField = ({value, options, onChange, includeEmptyRow}) => {

--- a/app/client/components/filter_panel.es6
+++ b/app/client/components/filter_panel.es6
@@ -132,7 +132,7 @@ export class ContextualValue extends React.Component {
 }
 
 const InputTextField = ({value, onChange}) => {
-  return <input type="text" className="form-control" onChange={onChange} value={value} placeholder={'Value'} />
+  return <input type="text" className="form-control" onChange={onChange} value={value} placeholder='Value' />
 };
 
 const ListField = ({value, options, onChange, includeEmptyRow}) => {

--- a/app/client/components/filter_panel.es6
+++ b/app/client/components/filter_panel.es6
@@ -38,11 +38,11 @@ class FilterPanel extends React.Component {
 
     return (
       <Panel>
-        <Heading title='Add Filter' />
+        <Heading title='Add Filter'><OverlayTrigger trigger={['hover', 'focus']} placement="right" overlay={popoverHover} >
+          <span style={{ color: '#367FD2', width: '400px' }}>What&#39;s this?</span>
+        </OverlayTrigger></Heading>
         <Body>
-          <OverlayTrigger trigger={['hover', 'focus']} placement="right" overlay={popoverHover} >
-            <button>What&#39;s this?</button>
-          </OverlayTrigger>
+
 
           <CSSTransitionGroup transitionName="example" transitionEnterTimeout={1000} transitionLeaveTimeout={300}>
             {filter_rows}

--- a/app/client/components/search_results_table.es6
+++ b/app/client/components/search_results_table.es6
@@ -16,15 +16,13 @@ class SearchResultsTable extends React.Component {
 
     return (
       <div>
-        <PaginationLinks links={links} dispatch={dispatch}></PaginationLinks>
-
         <Panel>
           <div className="row">
             <div className="col-md-12">
               { hasResults && <ButtonsPanel /> }
             </div>
           </div>
-
+          <PaginationLinks links={links} dispatch={dispatch}></PaginationLinks>
           <Heading title={title}>
           </Heading>
 
@@ -40,9 +38,9 @@ class SearchResultsTable extends React.Component {
               </tbody>
             </table>
           </Body>
+          <PaginationLinks links={links} dispatch={dispatch} />
         </Panel>
 
-        <PaginationLinks links={links} dispatch={dispatch} />
 
       </div>
     );

--- a/app/client/components/search_results_table.es6
+++ b/app/client/components/search_results_table.es6
@@ -22,11 +22,11 @@ class SearchResultsTable extends React.Component {
               { hasResults && <ButtonsPanel /> }
             </div>
           </div>
-          <PaginationLinks links={links} dispatch={dispatch}></PaginationLinks>
           <Heading title={title}>
           </Heading>
+          <PaginationLinks links={links} dispatch={dispatch} />
 
-          <Body style={{overflow: 'scroll'}}>
+          <Body style={{overflow: 'scroll', paddingBottom: '0', paddingTop: '0'}}>
             <table className="table table-striped table-hover search-results-table">
               <thead>
                 <tr>

--- a/app/client/components/stamper_panel.es6
+++ b/app/client/components/stamper_panel.es6
@@ -29,12 +29,12 @@ const StamperPanel = ({stamps, selectedStamp, status, onStampClick, onUnstampCli
       <form className="form col-md-4">
         <label>
           Select a stamp:
+        </label>
           <select className='form-control' defaultValue={selectedStampId} onChange={ onChangeSelectedStamp }>
             { stampsOptions }
           </select>
-        </label>
-        <button disabled={loading.stamping} type="button" className="btn btn-primary stamp-btn" onClick={ () => { onStampClick(selectedStampId) } }>Apply</button>
-        <button disabled={loading.stamping} type="button" className="btn btn-danger stamp-btn" onClick={ () => { onUnstampClick(selectedStampId) } }>Unapply</button>
+        <button disabled={loading.stamping} type="button" className="btn btn-primary set-btn" onClick={ () => { onStampClick(selectedStampId) } }>Apply</button>
+        <button disabled={loading.stamping} type="button" className="btn btn-danger set-btn" onClick={ () => { onUnstampClick(selectedStampId) } }>Unapply</button>
         { loading.stamping && <FontAwesome icon="spinner fa-spin" size="lg"></FontAwesome> }
       </form>
     );

--- a/app/client/components/stamper_panel.es6
+++ b/app/client/components/stamper_panel.es6
@@ -26,15 +26,15 @@ const StamperPanel = ({stamps, selectedStamp, status, onStampClick, onUnstampCli
     const selectedStampId = selectedStamp ? selectedStamp.id : stamps[0].id;
 
     return (
-      <form className="form-inline" style={{marginTop: '5px'}}>
+      <form className="form col-md-4">
         <label>
           Select a stamp:
-          <select className='form-control' defaultValue={selectedStampId} onChange={ onChangeSelectedStamp } style={{marginLeft: '10px'}}>
+          <select className='form-control' defaultValue={selectedStampId} onChange={ onChangeSelectedStamp }>
             { stampsOptions }
           </select>
         </label>
-        <button style={{marginLeft: '10px'}} disabled={loading.stamping} type="button" className="btn btn-primary" onClick={ () => { onStampClick(selectedStampId) } }>Apply</button>
-        <button style={{marginLeft: '10px'}} disabled={loading.stamping} type="button" className="btn btn-primary" onClick={ () => { onUnstampClick(selectedStampId) } }>Unapply</button>
+        <button disabled={loading.stamping} type="button" className="btn btn-primary stamp-btn" onClick={ () => { onStampClick(selectedStampId) } }>Apply</button>
+        <button disabled={loading.stamping} type="button" className="btn btn-danger stamp-btn" onClick={ () => { onUnstampClick(selectedStampId) } }>Unapply</button>
         { loading.stamping && <FontAwesome icon="spinner fa-spin" size="lg"></FontAwesome> }
       </form>
     );

--- a/app/client/containers/buttons_panel_container.es6
+++ b/app/client/containers/buttons_panel_container.es6
@@ -45,7 +45,7 @@ class ButtonsPanelContainer extends React.Component {
 
     return (
         <Body>
-          <form className="form-inline" id="create-set">
+          <form className="form-inline pull-left" id="create-set">
             <label>
               Create new set:
               <input type="text" style={{marginLeft: '10px'}} className="form-control" placeholder="Set name" onChange={this.handleChangeCreateNewSet} />
@@ -53,7 +53,7 @@ class ButtonsPanelContainer extends React.Component {
             <button onClick={this.handleClickCreateNewSet} disabled={loading.creatingSet} style={{marginLeft: '10px'}} type="submit" className="btn btn-primary">Create</button>
             { loading.creatingSet && <FontAwesome icon="spinner fa-spin" size="lg"></FontAwesome> }
           </form>
-          <form className="form-inline" id="add-remove-materials-from-set">
+          <form className="form-inline pull-right" id="add-remove-materials-from-set">
             <label>
               Select a set:
             </label>

--- a/app/client/containers/buttons_panel_container.es6
+++ b/app/client/containers/buttons_panel_container.es6
@@ -58,10 +58,12 @@ class ButtonsPanelContainer extends React.Component {
               Select a set:
             </label>
             <ListSets sets={sets} onChange={this.handleChangeAddRemoveMaterialsFromSet} />
+            <div className="btn-toolbar">
             <button id="add-button" onClick={this.handleClickAddMaterialsToSet} disabled={loading.addMaterialsToSet} type="submit" className="btn btn-primary set-btn">Add Materials To Set</button>
             { loading.addMaterialsToSet && <FontAwesome icon="spinner fa-spin" size="lg"></FontAwesome> }
             <button id="remove-button" onClick={this.handleClickRemoveMaterialsFromSet} disabled={loading.removeMaterialsFromSet} type="submit" className="btn btn-danger set-btn">Remove Materials From Set</button>
             { loading.removeMaterialsFromSet && <FontAwesome icon="spinner fa-spin" size="lg"></FontAwesome> }
+            </div>
           </form>
           <StamperControl></StamperControl>
         </Body>

--- a/app/client/containers/buttons_panel_container.es6
+++ b/app/client/containers/buttons_panel_container.es6
@@ -48,9 +48,9 @@ class ButtonsPanelContainer extends React.Component {
           <form className="form col-md-4" id="create-set">
             <label>
               Create new set:
-              <input type="text" style={{marginLeft: '10px'}} className="form-control" placeholder="Set name" onChange={this.handleChangeCreateNewSet} />
             </label>
-            <button onClick={this.handleClickCreateNewSet} disabled={loading.creatingSet} type="submit" className="btn btn-primary" id="create-set-btn">Create</button>
+              <input type="text" className="form-control" placeholder="Set name" onChange={this.handleChangeCreateNewSet} />
+            <button onClick={this.handleClickCreateNewSet} disabled={loading.creatingSet} type="submit" className="btn btn-primary set-btn">Create</button>
             { loading.creatingSet && <FontAwesome icon="spinner fa-spin" size="lg"></FontAwesome> }
           </form>
           <form className="form col-md-4" id="add-remove-materials-from-set">
@@ -58,9 +58,9 @@ class ButtonsPanelContainer extends React.Component {
               Select a set:
             </label>
             <ListSets sets={sets} onChange={this.handleChangeAddRemoveMaterialsFromSet} />
-            <button id="add-button" onClick={this.handleClickAddMaterialsToSet} disabled={loading.addMaterialsToSet} type="submit" className="btn btn-primary mat-btn">Add Materials To Set</button>
+            <button id="add-button" onClick={this.handleClickAddMaterialsToSet} disabled={loading.addMaterialsToSet} type="submit" className="btn btn-primary set-btn">Add Materials To Set</button>
             { loading.addMaterialsToSet && <FontAwesome icon="spinner fa-spin" size="lg"></FontAwesome> }
-            <button id="remove-button" onClick={this.handleClickRemoveMaterialsFromSet} disabled={loading.removeMaterialsFromSet} type="submit" className="btn btn-danger mat-btn">Remove Materials From Set</button>
+            <button id="remove-button" onClick={this.handleClickRemoveMaterialsFromSet} disabled={loading.removeMaterialsFromSet} type="submit" className="btn btn-danger set-btn">Remove Materials From Set</button>
             { loading.removeMaterialsFromSet && <FontAwesome icon="spinner fa-spin" size="lg"></FontAwesome> }
           </form>
           <StamperControl></StamperControl>
@@ -77,7 +77,7 @@ const ListSets = ({sets, onChange}) => {
   });
 
   return (
-    <select onChange={onChange} className="form-control" style={{marginLeft: '10px'}}>
+    <select onChange={onChange} className="form-control">
       { optionTags }
     </select>
   );

--- a/app/client/containers/buttons_panel_container.es6
+++ b/app/client/containers/buttons_panel_container.es6
@@ -45,22 +45,22 @@ class ButtonsPanelContainer extends React.Component {
 
     return (
         <Body>
-          <form className="form-inline pull-left" id="create-set">
+          <form className="form col-md-4" id="create-set">
             <label>
               Create new set:
               <input type="text" style={{marginLeft: '10px'}} className="form-control" placeholder="Set name" onChange={this.handleChangeCreateNewSet} />
             </label>
-            <button onClick={this.handleClickCreateNewSet} disabled={loading.creatingSet} style={{marginLeft: '10px'}} type="submit" className="btn btn-primary">Create</button>
+            <button onClick={this.handleClickCreateNewSet} disabled={loading.creatingSet} type="submit" className="btn btn-primary" id="create-set-btn">Create</button>
             { loading.creatingSet && <FontAwesome icon="spinner fa-spin" size="lg"></FontAwesome> }
           </form>
-          <form className="form-inline pull-right" id="add-remove-materials-from-set">
+          <form className="form col-md-4" id="add-remove-materials-from-set">
             <label>
               Select a set:
             </label>
             <ListSets sets={sets} onChange={this.handleChangeAddRemoveMaterialsFromSet} />
-            <button id="add-button" onClick={this.handleClickAddMaterialsToSet} disabled={loading.addMaterialsToSet} style={{marginLeft: '10px'}} type="submit" className="btn btn-primary">Add Materials To Set</button>
+            <button id="add-button" onClick={this.handleClickAddMaterialsToSet} disabled={loading.addMaterialsToSet} type="submit" className="btn btn-primary mat-btn">Add Materials To Set</button>
             { loading.addMaterialsToSet && <FontAwesome icon="spinner fa-spin" size="lg"></FontAwesome> }
-            <button id="remove-button" onClick={this.handleClickRemoveMaterialsFromSet} disabled={loading.removeMaterialsFromSet} style={{marginLeft: '10px'}} type="submit" className="btn btn-primary">Remove Materials From Set</button>
+            <button id="remove-button" onClick={this.handleClickRemoveMaterialsFromSet} disabled={loading.removeMaterialsFromSet} type="submit" className="btn btn-danger mat-btn">Remove Materials From Set</button>
             { loading.removeMaterialsFromSet && <FontAwesome icon="spinner fa-spin" size="lg"></FontAwesome> }
           </form>
           <StamperControl></StamperControl>

--- a/app/client/layouts/search.es6
+++ b/app/client/layouts/search.es6
@@ -20,11 +20,11 @@ const Search = ({ search, loading }) => {
         <UserMessage></UserMessage>
 
         <div className="row">
-          <div className="col-md-6">
+          <div className="col-md-7">
             <FilterPanel filters={search.filters} fields={search.fields} />
           </div>
 
-          <div className="col-md-6">
+          <div className="col-md-5">
             <CurrentSearch current={search.current} />
           </div>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,7 @@
             <li><%= link_to 'Advanced', search_url, id: ('current_page' if params[:action] == 'search') %></li>
           </ul>
           <ul class="nav navbar-nav navbar-right">
+            <li><p class="navbar-text">Logged in as <%= current_user.email.split('@')[0] %></p></li>
             <li><%= link_to 'Log Out', destroy_user_session_url, method: :delete if user_signed_in? %></li>
           </ul>
         </div>


### PR DESCRIPTION
- Pagination links have been moved so they're inside the panel with the table, so are much closer to the data they manipulate
- The "what's this" button has been changed to a link and moved into the "Add Filter" panel header
- The popover has been made wider
- Currently logged in user is now shown in the navigation bar (takes the part of the email address before @)
- The "Add Filter" column is now wider than "Current Search"
- Forms for manipulating sets have been put into a column each and buttons styled to reflect their actions

### Before
![screen shot 2017-09-22 at 10 51 42](https://user-images.githubusercontent.com/18176485/30739336-d3c63776-9f84-11e7-8b18-d938671c7f73.png)

### After
![screen shot 2017-09-22 at 15 17 33](https://user-images.githubusercontent.com/18176485/30748785-37a2775e-9fa9-11e7-90a8-cc106fb9d751.png)


