### PR TITLE
Attempting to bugfix missing page number

### DIFF
--- a/app/client/actions/index.es6
+++ b/app/client/actions/index.es6
@@ -124,20 +124,21 @@ const urlForMaterialsFromSet = function(setId, pageNumber, pageSize) {
 export const FETCH_MATERIALS_FROM_SET_BY_URL = "FETCH_MATERIALS_FROM_SET_BY_URL";
 export const fetchMaterialsFromSetByUrl = function(url) {
   const setId = url.match(/sets\/([^/]*)/)[1]
-  const pageNumber = url.match(new RegExp(encodeURI("page[number]") + "=(\\d*)"))[1]
-  const pageSize = url.match(new RegExp(encodeURI("page[size]") + "=(\\d*)"))[1]
+  const pageNumber = url.match(new RegExp(encodeURI("page[number]") + "=(\\d+)"))[1]
+  const pageSize = url.match(new RegExp(encodeURI("page[size]") + "=(\\d+)"))[1]
 
   return function(dispatch) {
-    return dispatch(readEndpoint(urlForMaterialsFromSet(setId, pageNumber, pageSize)))
-      .then((json) => { return dispatch(fetchMaterials(json.body, setId, pageNumber, url)) });
-  };
+    return fetchSetAndMaterials(setId, pageNumber, pageSize);
+  }
 }
 
 export const FETCH_SET_AND_MATERIALS = "FETCH_SET_AND_MATERIALS";
 export const fetchSetAndMaterials = function(setId, pageNumber, sizeNumber) {
+  const url = urlForMaterialsFromSet(setId, pageNumber, sizeNumber);
   return function(dispatch) {
-    return dispatch(fetchMaterialsFromSetByUrl(urlForMaterialsFromSet(setId, pageNumber, sizeNumber)));
-  }
+    return dispatch(readEndpoint(url))
+       .then((json) => { return dispatch(fetchMaterials(json.body, setId, pageNumber, url)) });
+  };
 }
 
 export const FETCH_FIRST_PAGE_SET_AND_MATERIALS = "FETCH_FIRST_PAGE_SET_AND_MATERIALS";


### PR DESCRIPTION
I'm hoping this will solve or reveal the bug related to occasional missing
page number in requests. I can't reproduce it locally.

Previously:
fetchSetAndMaterials has the page number and the page size. From
those it builds a url and calls
fetchMaterialsFromSetByUrl, which would then extract the details
from the url because it needed them. Better to issue the request
from fetchSetAndMaterials, where the details are known.

Also changed the regex for extracting page number from url
use \d+ instead of \d*, because if the page number is missing,
it won't work.