### PR TITLE
attempt to fix urls in table headings

### DIFF
--- a/app/javascript/presentation/material_table.js
+++ b/app/javascript/presentation/material_table.js
@@ -67,8 +67,12 @@ function TableSortHeader(props) {
   if (page) {
     search += '&page=' + page;
   }
+  let pathname = window.location.pathname;
+  if (pathname.startsWith('/set/')) {
+    pathname = pathname.substring(4);
+  }
   const target = ({
-      pathname: window.location.pathname.replace('/set', ''),
+      pathname: pathname,
       search: search
   });
   return (<th><Link to={target}>{children}{orderIcon}</Link></th>);

--- a/app/javascript/presentation/material_table.js
+++ b/app/javascript/presentation/material_table.js
@@ -68,7 +68,7 @@ function TableSortHeader(props) {
     search += '&page=' + page;
   }
   const target = ({
-      pathname: window.location.origin + window.location.pathname,
+      pathname: window.location.pathname.replace('/set', ''),
       search: search
   });
   return (<th><Link to={target}>{children}{orderIcon}</Link></th>);

--- a/app/javascript/presentation/material_table.js
+++ b/app/javascript/presentation/material_table.js
@@ -68,6 +68,7 @@ function TableSortHeader(props) {
     search += '&page=' + page;
   }
   const target = ({
+      origin: window.location.origin,
       pathname: window.location.pathname,
       search: search
   });

--- a/app/javascript/presentation/material_table.js
+++ b/app/javascript/presentation/material_table.js
@@ -68,7 +68,7 @@ function TableSortHeader(props) {
     search += '&page=' + page;
   }
   const target = ({
-      pathname: '',
+      pathname: window.location.origin + window.location.pathname,
       search: search
   });
   return (<th><Link to={target}>{children}{orderIcon}</Link></th>);

--- a/app/javascript/presentation/material_table.js
+++ b/app/javascript/presentation/material_table.js
@@ -68,8 +68,7 @@ function TableSortHeader(props) {
     search += '&page=' + page;
   }
   const target = ({
-      origin: window.location.origin,
-      pathname: window.location.pathname,
+      pathname: window.location.href,
       search: search
   });
   return (<th><Link to={target}>{children}{orderIcon}</Link></th>);

--- a/app/javascript/presentation/material_table.js
+++ b/app/javascript/presentation/material_table.js
@@ -68,7 +68,7 @@ function TableSortHeader(props) {
     search += '&page=' + page;
   }
   const target = ({
-      pathname: window.location.href,
+      pathname: '',
       search: search
   });
   return (<th><Link to={target}>{children}{orderIcon}</Link></th>);


### PR DESCRIPTION
When the shaper is deployed, the table header urls are broken.
This might fix them.